### PR TITLE
Update releases for:

### DIFF
--- a/data/firmwares/easyskymesh/changelog.yaml
+++ b/data/firmwares/easyskymesh/changelog.yaml
@@ -1,6 +1,6 @@
 source: github
 repo: IoTThinks/EasySkyMesh
-updatedAt: '2026-06-21T04:22:37.789Z'
+updatedAt: '2026-06-21T06:18:09.242Z'
 releases:
   - version: PowerSaving16
     name: 'Power Saving 16: Poweroff at 16uA, T096 at 8.7mA and auto reboot'

--- a/data/firmwares/meshcomod/changelog.yaml
+++ b/data/firmwares/meshcomod/changelog.yaml
@@ -1,6 +1,6 @@
 source: github
 repo: ALLFATHER-BV/meshcomod
-updatedAt: '2026-06-21T04:22:38.060Z'
+updatedAt: '2026-06-21T06:18:09.746Z'
 releases:
   - version: companion-v1.16.0.4
     name: Companion Firmware v1.16.0.4

--- a/data/firmwares/meshcore-evo/changelog.yaml
+++ b/data/firmwares/meshcore-evo/changelog.yaml
@@ -1,6 +1,6 @@
 source: github
 repo: mattzzw/MeshCore-Evo
-updatedAt: '2026-06-21T04:22:39.156Z'
+updatedAt: '2026-06-21T06:18:10.894Z'
 releases:
   - version: v1.15.0-evo_0.1.21
     name: Meshcore-evo build 1.15.0_0.1.21 - 25-May-2026

--- a/data/firmwares/meshcore-ng/changelog.yaml
+++ b/data/firmwares/meshcore-ng/changelog.yaml
@@ -1,6 +1,6 @@
 source: github
 repo: MichTronics/MeshCoreNG
-updatedAt: '2026-06-21T04:22:40.371Z'
+updatedAt: '2026-06-21T06:18:12.654Z'
 releases:
   - version: bridge-tcp-ble-v1.1.2
     name: TCP+BLE Bridge Firmware v1.1.2

--- a/data/firmwares/meshcore-official/changelog.yaml
+++ b/data/firmwares/meshcore-official/changelog.yaml
@@ -1,6 +1,6 @@
 source: script
 repo: meshcore-dev/MeshCore
-updatedAt: '2026-06-21T04:22:42.785Z'
+updatedAt: '2026-06-21T06:18:14.438Z'
 releases:
   - version: room-server-v1.16.0
     name: Room Server Firmware v1.16.0

--- a/data/firmwares/zephcore/changelog.yaml
+++ b/data/firmwares/zephcore/changelog.yaml
@@ -1,6 +1,6 @@
 source: github
 repo: liquidraver/ZephCore
-updatedAt: '2026-06-21T04:22:44.179Z'
+updatedAt: '2026-06-21T06:18:16.155Z'
 releases:
   - version: v20260619.094253
     name: Firmware v20260619.094253


### PR DESCRIPTION
- easyskymesh
- meshcomod
- meshcore-evo
- meshcore-ng
- meshcore-official
- zephcore

Ahoy,

mistral went through and update release status for the other firmware.